### PR TITLE
Fallback to abstract scraper image function

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -97,7 +97,7 @@ def root():
         return abort(501)
 
     try:
-        scraped_image = scrape.image()
+        scraped_image = scrape.image() or super(type(scrape), scrape).image()
     except NotImplementedError:
         return abort(501)
 


### PR DESCRIPTION
If a scraper does implement `image` retrieval, but returns no results, try falling back to the abstract super-class `image` method instead.

It's possible this functionality could be pushed into the `recipe-scrapers` library in future.  This could also do with some test coverage.