### PR TITLE
Add URL resolution endpoint

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,3 +16,4 @@ tldextract = "==2.2.2"
 [dev-packages]
 flake8 = "*"
 pytest = "*"
+responses = "*"

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,11 +1,32 @@
+import pytest
+import responses
+
 from web.app import get_domain
 
 
-def test_request(client):
-    client.post('/')
+@pytest.fixture
+def origin_url():
+    return 'https://recipe.subdomain.example.com/recipe/123'
 
 
-def test_get_domain():
-    domain = get_domain('https://recipe.subdomain.example.com/recipe/123')
+@pytest.fixture
+def content_url(origin_url):
+    return origin_url.replace('subdomain', 'migrated')
+
+
+def test_get_domain(origin_url):
+    domain = get_domain(origin_url)
 
     assert domain == 'example.com'
+
+
+@responses.activate
+def test_origin_url_resolution(client, origin_url, content_url):
+    redir_headers = {'Location': content_url}
+    responses.add(responses.GET, origin_url, status=301, headers=redir_headers)
+    responses.add(responses.GET, content_url, status=200)
+
+    response = client.post('/resolve', data={'url': origin_url})
+    recipe_url = response.json['resolves_to']
+
+    assert recipe_url == content_url

--- a/web/app.py
+++ b/web/app.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from flask import Flask, abort, jsonify, request
 from tldextract import TLDExtract
+from recipe_scrapers._abstract import HEADERS
 import requests
 from requests.exceptions import ConnectionError, ReadTimeout
 from time import sleep
@@ -70,7 +71,7 @@ def resolve():
     if not url:
         return abort(400)
 
-    response = requests.get(url)
+    response = requests.get(url, headers=HEADERS)
     return jsonify({
         'resolves_to': response.url
     })

--- a/web/app.py
+++ b/web/app.py
@@ -64,8 +64,20 @@ def get_domain(url):
     return f'{url_info.domain}.{url_info.suffix}'
 
 
-@app.route('/', methods=['POST'])
-def root():
+@app.route('/resolve', methods=['POST'])
+def resolve():
+    url = request.form.get('url')
+    if not url:
+        return abort(400)
+
+    response = requests.get(url)
+    return jsonify({
+        'resolves_to': response.url
+    })
+
+
+@app.route('/crawl', methods=['POST'])
+def crawl():
     url = request.form.get('url')
     if not url:
         return abort(400)


### PR DESCRIPTION
Prepares for migration of URL-resolution (essentially, following HTTP 301 and other redirects) from the `api` service into the `crawler` service.