### PR TITLE
Crawl recipes from last-known URL

### DIFF
--- a/reciperadar/recipes.py
+++ b/reciperadar/recipes.py
@@ -8,7 +8,7 @@ from actions import recrawl, reindex
 def query_recipes(where):
     where = where or 'true'
     query = (
-        f'select id, src, title '
+        f'select id, dst, title '
         f'from recipes '
         f'where {where} '
         f'order by random()'
@@ -17,8 +17,8 @@ def query_recipes(where):
     db = pg8000.connect(host='192.168.100.1', user='api', database='api')
     cursor = db.cursor()
     results = cursor.execute(query)
-    for recipe_id, src, title in results.fetchall():
-        yield recipe_id, src, title
+    for recipe_id, dst, title in results.fetchall():
+        yield recipe_id, dst, title
     cursor.close()
 
 
@@ -28,9 +28,9 @@ parser.add_argument('--recrawl', action='store_true', help='Invoke recrawling')
 parser.add_argument('--reindex', action='store_true', help='Invoke reindexing')
 args = parser.parse_args()
 
-for recipe_id, src, title in query_recipes(args.where):
+for recipe_id, dst, title in query_recipes(args.where):
     if args.recrawl:
-        recrawl(src)
+        recrawl(dst)
         print(f'* Queued recipe {title} for recrawling')
     elif args.reindex:
         reindex(recipe_id)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
When recrawling, it may be more efficient (in terms of reduced HTTP redirects) to start with the latest-known content URL.

### Briefly summarize the changes
1. Use the recipe `dst` attribute in preference to `src` when recrawling recipe content.

### How have the changes been tested?
1. This change is under evaluation at the time-of-writing.

**List any issues that this change relates to**
Relates to https://github.com/openculinary/api/issues/3
Relates to https://github.com/openculinary/api/pull/45