### PR TITLE
Update to recipe-scrapers v7.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,21 @@ image:
 	$(eval container=$(shell buildah from docker.io/library/python:3.8-alpine))
 	buildah copy $(container) 'web' 'web'
 	buildah copy $(container) 'Pipfile'
+	buildah run $(container) -- apk add py3-lxml --
 	buildah run $(container) -- pip install pipenv --
+	# Begin: NOTE: These are build-time dependencies required by lxml (for extruct)
+	buildah run $(container) -- apk add gcc --
+	buildah run $(container) -- apk add libxml2-dev --
+	buildah run $(container) -- apk add libxslt-dev --
+	buildah run $(container) -- apk add musl-dev --
+	# End: NOTE
 	buildah run $(container) -- pipenv install --
+	# Begin: NOTE: These are build-time dependencies required by lxml (for extruct)
+	buildah run $(container) -- apk del gcc --
+	buildah run $(container) -- apk del libxml2-dev --
+	buildah run $(container) -- apk del libxslt-dev --
+	buildah run $(container) -- apk del musl-dev --
+	# End: NOTE
 	buildah config --port 80 --entrypoint 'pipenv run gunicorn web.app:app --bind :80' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}
 

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.8"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
-recipe-scrapers = "==5.18.0"
+recipe-scrapers = "==7.2.0"
 requests = "==2.22.0"
 tldextract = "==2.2.2"
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Upgrade to the latest version of [recipe-scrapers](https://github.com/hhursev/recipe-scrapers/) library to include support for additional recipe websites and bugfixes.

This does introduce additional build-time dependencies required for `lxml` (pulled in by `extruct`, required pending any alternatives discovered by https://github.com/hhursev/recipe-scrapers/issues/150).

### Briefly summarize the changes
1. Add `lxml` build-time dependencies to the container build makefile
1. Update the `recipe-scrapers` version to 7.2.0

### How have the changes been tested?
1. Local testing against an example recipe URL