### PR TITLE
Enable application<->pod introspection via service account

### DIFF
--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -15,6 +15,7 @@ spec:
         app: crawler
         role: web
     spec:
+      serviceAccountName: crawler-serviceaccount
       containers:
       - image: registry.openculinary.org/reciperadar/crawler
         imagePullPolicy: IfNotPresent

--- a/k8s/web-serviceaccount.yaml
+++ b/k8s/web-serviceaccount.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crawler-serviceaccount
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: crawler-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: crawler-clusterrole-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crawler-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: crawler-serviceaccount
+    namespace: default


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As part of openculinary/frontend#94, we would like to display the version -- an abbreviated git commit ID -- of the [crawler](https://github.com/openculinary/crawler) application used to retrieve recipe content, both for historic and current recipe content.

This requirement implies that the `crawler` service should report its' current version at runtime and expose this as part of its' API responses.

There are multiple places we *could* choose to provide the git commit ID to the `crawler` application:

- Embedding the ID into the Python application code
- Writing the ID into the container filesystem at image build time
- Extracting the git commit ID that is already [embedded in the container image ID](https://github.com/openculinary/crawler/blob/a09dc205e18fc7cb782cb3f55ce09d52a1b7aa6a/Makefile#L8) from the pod metadata at runtime

Of these three options, the latter retains a nice property that the container build process requires no modifications, and also means that churn of filesystem content is not required during every container update.

There is an official Kubernetes Python client that includes an [example of k8s-apiserver interaction via in-cluster-config](https://github.com/kubernetes-client/python/blob/e60d9212c6a451a8617e2116fe49589213fad73b/examples/in_cluster_config.py).

It does require opening up access control within the k8s cluster via [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/), and it's worth being careful about that.

It doesn't currently seem possible to dynamically restrict the `resourceNames` in a role to bind them to the same-name-as-the-originating-pod; i.e. we can't enforce that an application can *only* access the pod it is part of.

However, we can restrict the role to only use the `get` verb and only the `pod` k8s resource.  As long as the application cannot use the `list` verb on `pod` resources, it should not be able to know the name of any pods *except* for itself, since the pod name is also the application host environment's `hostname`.

### Briefly summarize the changes
1. Create a new k8s service account specific to the `crawler` service
1. Create a new k8s role providing `verb:get` `resource:pod` k8s RBAC permissions
1. Bind the `crawler` service account to the new role
1. Use the `crawler` service account for `crawler` container deployments

### How have the changes been tested?
1. Local testing in a development cluster

**List any issues that this change relates to**
Relates to openculinary/frontend#94