### PR TITLE
Add versioning metadata to crawl endpoint API responses

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ python_version = "3.8"
 [packages]
 flask = "==1.1.2"
 gunicorn = "==20.0.4"
+kubernetes = "==11.0.0"
 recipe-scrapers = "==7.2.0"
 requests = "==2.22.0"
 tldextract = "==2.2.2"

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -77,7 +77,10 @@ def test_crawl_response(image_version, scrape_recipe, parse_directions,
     parse_ingredients.return_value = ['test ingredient']
 
     response = client.post('/crawl', data={'url': content_url})
-    service_version = response.json.get('metadata', {}).get('service_version')
+    metadata = response.json.get('metadata', {})
+    service_version = metadata.get('service_version')
+    rs_version = metadata.get('recipe_scrapers_version')
 
     assert response.status_code == 200
     assert service_version == 'test_version'
+    assert rs_version == '8.2.0'

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,5 +1,6 @@
 import pytest
 import responses
+from unittest.mock import patch
 
 from web.app import get_domain
 
@@ -21,7 +22,8 @@ def test_get_domain(origin_url):
 
 
 @responses.activate
-def test_origin_url_resolution(client, origin_url, content_url):
+@patch('web.app.determine_image_version')
+def test_origin_url_resolution(image_version, client, origin_url, content_url):
     redir_headers = {'Location': content_url}
     responses.add(responses.GET, origin_url, status=301, headers=redir_headers)
     responses.add(responses.GET, content_url, status=200)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -2,7 +2,7 @@ import pytest
 import responses
 from unittest.mock import patch
 
-from web.app import get_domain
+from web.app import app, get_domain
 
 
 @pytest.fixture
@@ -32,3 +32,52 @@ def test_origin_url_resolution(image_version, client, origin_url, content_url):
     recipe_url = response.json['resolves_to']
 
     assert recipe_url == content_url
+
+
+@pytest.fixture
+def scrape_result():
+    class ScrapeResult(object):
+
+        def title(self):
+            return 'test'
+
+        def image(self):
+            return 'test.png'
+
+        def instructions(self):
+            return 'test'
+
+        def total_time(self):
+            return 60
+
+        def ingredients(self):
+            return ['test']
+
+        def ratings(self):
+            return 5
+
+        def yields(self):
+            return '1'
+
+    return ScrapeResult()
+
+
+@patch('web.app.parse_ingredients')
+@patch('web.app.parse_directions')
+@patch('web.app.scrape_recipe')
+@patch('web.app.determine_image_version')
+def test_crawl_response(image_version, scrape_recipe, parse_directions,
+                        parse_ingredients, client, content_url, scrape_result):
+    # HACK: Ensure that app initialization methods (re)run during this test
+    app._got_first_request = False
+
+    image_version.return_value = 'test_version'
+    scrape_recipe.return_value = scrape_result
+    parse_directions.return_value = ['test direction']
+    parse_ingredients.return_value = ['test ingredient']
+
+    response = client.post('/crawl', data={'url': content_url})
+    service_version = response.json.get('metadata', {}).get('service_version')
+
+    assert response.status_code == 200
+    assert service_version == 'test_version'

--- a/web/app.py
+++ b/web/app.py
@@ -151,13 +151,18 @@ def crawl():
     rating = 4.75 if rating == 5.0 else rating
 
     return jsonify({
-        'title': scrape.title(),
-        'src': url,
-        'domain': domain,
-        'ingredients': ingredients,
-        'directions': directions,
-        'image_src': urljoin(url, scraped_image),
-        'servings': servings,
-        'time': time,
-        'rating': rating,
+        'metadata': {
+            'service_version': image_version,
+        },
+        'result': {
+            'title': scrape.title(),
+            'src': url,
+            'domain': domain,
+            'ingredients': ingredients,
+            'directions': directions,
+            'image_src': urljoin(url, scraped_image),
+            'servings': servings,
+            'time': time,
+            'rating': rating,
+        },
     })

--- a/web/app.py
+++ b/web/app.py
@@ -156,7 +156,7 @@ def crawl():
         'metadata': {
             'service_version': app.image_version,
         },
-        'result': {
+        'recipe': {
             'title': scrape.title(),
             'src': url,
             'domain': domain,

--- a/web/app.py
+++ b/web/app.py
@@ -68,13 +68,17 @@ def get_domain(url):
 
 
 @app.before_first_request
+def before_first_request():
+    app.image_version = determine_image_version()
+
+
 def determine_image_version():
     kubernetes.config.load_incluster_config()
     client = kubernetes.client.CoreV1Api()
     pod = client.read_namespaced_pod(namespace='default', name=gethostname())
     app = pod.metadata.labels['app']
     container = next(filter(lambda c: c.name == app, pod.spec.containers))
-    app.image_version = container.image.split(':')[-1] if container else None
+    return container.image.split(':')[-1] if container else None
 
 
 @app.route('/resolve', methods=['POST'])

--- a/web/app.py
+++ b/web/app.py
@@ -10,6 +10,7 @@ from time import sleep
 from urllib.parse import urljoin
 
 from recipe_scrapers import (
+    __version__ as rs_version,
     scrape_me as scrape_recipe,
     WebsiteNotImplementedError,
 )
@@ -155,6 +156,7 @@ def crawl():
     return jsonify({
         'metadata': {
             'service_version': app.image_version,
+            'recipe_scrapers_version': rs_version,
         },
         'recipe': {
             'title': scrape.title(),


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
It's useful for debugging purposes to view and potentially record the version of the `crawler` container image and `recipe-scrapers` library used in conjunction to extract recipe metadata from the web.

### Briefly summarize the changes
1. Add the native Python Kubernetes client to the `crawler` application's dependencies
1. Retrieve the current image version from the Kubernetes API server at application runtime
1. Report the container image version and `recipe-scrapers` library version during `POST /crawl` API responses

### How have the changes been tested?
1. Local development testing
1. Additional unit test coverage is provided

**List any issues that this change relates to**
Relates to openculinary/frontend#94