### PR TITLE
Add human-readable crawler error responses

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -86,7 +86,9 @@ def determine_image_version():
 def resolve():
     url = request.form.get('url')
     if not url:
-        return jsonify({'error': 'url parameter is required'}), 400
+        return jsonify({'error': {
+            'message': 'url parameter is required',
+        }}), 400
 
     response = requests.get(url, headers=HEADERS)
     return jsonify({
@@ -104,7 +106,9 @@ def resolve():
 def crawl():
     url = request.form.get('url')
     if not url:
-        return jsonify({'error': 'url parameter is required'}), 400
+        return jsonify({'error': {
+            'message': 'url parameter is required',
+        }}), 400
 
     domain = get_domain(url)
     if domain in domain_backoffs:
@@ -114,7 +118,9 @@ def crawl():
         if datetime.utcnow() < (start + duration):
             print(f'* Backing off for {domain}')
             sleep(duration.seconds)
-            return jsonify({'error': f'backing off for {domain}'}), 429
+            return jsonify({'error': {
+                'message': f'backing off for {domain}'
+            }}), 429
 
     try:
         scrape = scrape_recipe(url)
@@ -128,27 +134,39 @@ def crawl():
         }
         print(f'* Setting backoff on {domain} for {duration.seconds} seconds')
         sleep(duration.seconds)
-        return jsonify({'error': f'timeout; adding backoff for {domain}'}), 429
+        return jsonify({'error': {
+            'message': f'timeout; adding backoff for {domain}',
+        }}), 429
     except WebsiteNotImplementedError:
-        return jsonify({'error': 'website is not implemented'}), 501
+        return jsonify({'error': {
+            'message': 'website is not implemented'
+        }}), 501
 
     try:
         scraped_image = scrape.image() or super(type(scrape), scrape).image()
     except NotImplementedError:
-        return jsonify({'error': 'image retrieval is not implemented'}), 501
+        return jsonify({'error': {
+            'message': 'image retrieval is not implemented',
+        }}), 501
 
     if not scraped_image:
-        return jsonify({'error': 'could not find recipe image'}), 404
+        return jsonify({'error': {
+            'message': 'could not find recipe image',
+        }}), 404
 
     directions = parse_directions(scrape.instructions().split('\n'))
     ingredients = parse_ingredients(scrape.ingredients())
 
     if not ingredients:
-        return jsonify({'error': 'could not find recipe ingredient'}), 404
+        return jsonify({'error': {
+            'message': 'could not find recipe ingredient'
+        }}), 404
 
     time = scrape.total_time()
     if not time:
-        return jsonify({'error': 'could not find recipe timing info'}), 404
+        return jsonify({'error': {
+            'message': 'could not find recipe timing info',
+        }}), 404
 
     servings = int(scrape.yields().split(' ')[0] or '1')
 

--- a/web/app.py
+++ b/web/app.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from flask import Flask, abort, jsonify, request
+from flask import Flask, jsonify, request
 import kubernetes
 from tldextract import TLDExtract
 import requests
@@ -86,7 +86,7 @@ def determine_image_version():
 def resolve():
     url = request.form.get('url')
     if not url:
-        return abort(400)
+        return jsonify({'error': 'url parameter is required'}), 400
 
     response = requests.get(url, headers=HEADERS)
     return jsonify({
@@ -104,7 +104,7 @@ def resolve():
 def crawl():
     url = request.form.get('url')
     if not url:
-        return abort(400)
+        return jsonify({'error': 'url parameter is required'}), 400
 
     domain = get_domain(url)
     if domain in domain_backoffs:
@@ -114,7 +114,7 @@ def crawl():
         if datetime.utcnow() < (start + duration):
             print(f'* Backing off for {domain}')
             sleep(duration.seconds)
-            return abort(429)
+            return jsonify({'error': f'backing off for {domain}'}), 429
 
     try:
         scrape = scrape_recipe(url)
@@ -128,27 +128,27 @@ def crawl():
         }
         print(f'* Setting backoff on {domain} for {duration.seconds} seconds')
         sleep(duration.seconds)
-        return abort(429)
+        return jsonify({'error': f'timeout; adding backoff for {domain}'}), 429
     except WebsiteNotImplementedError:
-        return abort(501)
+        return jsonify({'error': 'website is not implemented'}), 501
 
     try:
         scraped_image = scrape.image() or super(type(scrape), scrape).image()
     except NotImplementedError:
-        return abort(501)
+        return jsonify({'error': 'image retrieval is not implemented'}), 501
 
     if not scraped_image:
-        return abort(404)
+        return jsonify({'error': 'could not find recipe image'}), 404
 
     directions = parse_directions(scrape.instructions().split('\n'))
     ingredients = parse_ingredients(scrape.ingredients())
 
     if not ingredients:
-        return abort(404)
+        return jsonify({'error': 'could not find recipe ingredient'}), 404
 
     time = scrape.total_time()
     if not time:
-        return abort(404)
+        return jsonify({'error': 'could not find recipe timing info'}), 404
 
     servings = int(scrape.yields().split(' ')[0] or '1')
 

--- a/web/app.py
+++ b/web/app.py
@@ -119,7 +119,7 @@ def crawl():
             print(f'* Backing off for {domain}')
             sleep(duration.seconds)
             return jsonify({'error': {
-                'message': f'backing off for {domain}'
+                'message': f'backing off for {domain}',
             }}), 429
 
     try:
@@ -139,7 +139,7 @@ def crawl():
         }}), 429
     except WebsiteNotImplementedError:
         return jsonify({'error': {
-            'message': 'website is not implemented'
+            'message': 'website is not implemented',
         }}), 501
 
     try:
@@ -159,7 +159,7 @@ def crawl():
 
     if not ingredients:
         return jsonify({'error': {
-            'message': 'could not find recipe ingredient'
+            'message': 'could not find recipe ingredient',
         }}), 404
 
     time = scrape.total_time()


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Although the service attempts to return a relevant HTTP status code during crawling failures, some of those status codes may occur for multiple different reasons.  For example, failure to find a recipe at all, failure to find an image for a recipe, and failure to find ingredients for a recipe will all currently return an HTTP 404 status.

This change makes it easier to determine exactly why a crawler failure occurred for a given recipe by including a human-readable error message in the response.

### Briefly summarize the changes
1. Add human-readable `error.message` fields to each error case

### How have the changes been tested?
1. Unit tests continue to pass
2. Local development testing