### PR TITLE
Make concurrent parser requests by using requests-futures 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ gunicorn = "==20.0.4"
 kubernetes = "==11.0.0"
 recipe-scrapers = "==9.2.4"
 requests = "==2.24.0"
+requests-futures = "==1.0.0"
 tldextract = "==2.2.2"
 
 [dev-packages]

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -76,18 +76,21 @@ def scrape_result():
 
 
 @patch('web.app.parse_ingredients')
+@patch('web.app.format_ingredients')
 @patch('web.app.parse_directions')
+@patch('web.app.format_directions')
 @patch('web.app.scrape_recipe')
 @patch('web.app.determine_image_version')
-def test_crawl_response(image_version, scrape_recipe, parse_directions,
+def test_crawl_response(image_version, scrape_recipe, format_directions,
+                        parse_directions, format_ingredients,
                         parse_ingredients, client, content_url, scrape_result):
     # HACK: Ensure that app initialization methods (re)run during this test
     app._got_first_request = False
 
     image_version.return_value = 'test_version'
     scrape_recipe.return_value = scrape_result
-    parse_directions.return_value = ['test direction']
-    parse_ingredients.return_value = ['test ingredient']
+    format_directions.return_value = ['test direction']
+    format_ingredients.return_value = ['test ingredient']
 
     response = client.post('/crawl', data={'url': content_url})
     metadata = response.json.get('metadata', {})

--- a/web/app.py
+++ b/web/app.py
@@ -4,6 +4,7 @@ import kubernetes
 from tldextract import TLDExtract
 import requests
 from requests.exceptions import ConnectionError, ReadTimeout
+from requests_futures.sessions import FuturesSession
 from socket import gethostname
 from time import sleep
 from urllib.parse import urljoin
@@ -35,27 +36,33 @@ requests.sessions.Session.request = request_patch
 app = Flask(__name__)
 
 
-def parse_directions(descriptions):
-    directions = requests.post(
+def parse_directions(session, descriptions):
+    return session.post(
         url='http://direction-parser-service',
         data={'descriptions[]': descriptions},
         proxies={}
-    ).json()
+    )
+
+
+def format_directions(directions):
     return [
         {**{'index': index}, **direction}
-        for index, direction in enumerate(directions)
+        for index, direction in enumerate(directions.result().json())
     ]
 
 
-def parse_ingredients(descriptions):
-    ingredients = requests.post(
+def parse_ingredients(session, descriptions):
+    return session.post(
         url='http://ingredient-parser-service',
         data={'descriptions[]': descriptions},
         proxies={}
-    ).json()
+    )
+
+
+def format_ingredients(ingredients):
     return [
         {**{'index': index}, **ingredient}
-        for index, ingredient in enumerate(ingredients)
+        for index, ingredient in enumerate(ingredients.result().json())
     ]
 
 
@@ -154,10 +161,13 @@ def crawl():
             'message': 'could not find recipe image',
         }}, 404
 
-    directions = parse_directions(scrape.instructions().split('\n'))
-    ingredients = scrape.ingredients()
+    session = FuturesSession()
+    directions = parse_directions(session, scrape.instructions().split('\n'))
+    ingredients = parse_ingredients(session, scrape.ingredients())
+
+    directions = format_directions(directions)
     try:
-        ingredients = parse_ingredients(ingredients)
+        ingredients = format_ingredients(ingredients)
     except Exception:
         return {'error': {
             'message': f'ingredient parsing failed for: {ingredients}'


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Parsing recipe contents includes parsing of the ingredient list and direction list retrieved by the scraper.

This has previously been implemented by making two sequential HTTP requests - first, a request to the [`direction-parser`](https://github.com/openculinary/direction-parser) service, and then a request to the [`ingredient-parser`](https://github.com/openculinary/ingredient-parser) service.  This is inefficient because spend a lot of time within the crawler application waiting for precisely one or other of the services to respond before work can continue.

This change introduces use of the [`requests-futures`](https://pypi.org/project/requests-futures/) Python library, allowing us to begin work on both requests concurrently before waiting for and combining their results.

### Briefly summarize the changes
1. Introduce the `requests-futures` dependency
1. Implement concurrent parser requests

### How have the changes been tested?
1. Local development testing
1. Unit test coverage is updated