### PR TITLE
Add retrieval of author field from scrape results

### DIFF
--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -54,6 +54,9 @@ def scrape_result():
         def title(self):
             return 'test'
 
+        def author(self):
+            return 'test'
+
         def image(self):
             return 'test.png'
 

--- a/web/app.py
+++ b/web/app.py
@@ -150,6 +150,11 @@ def crawl():
         }}, 501
 
     try:
+        author = scrape.author()
+    except NotImplementedError:
+        author = None
+
+    try:
         scraped_image = scrape.image() or super(type(scrape), scrape).image()
     except NotImplementedError:
         return {'error': {
@@ -204,6 +209,7 @@ def crawl():
             'domain': domain,
             'ingredients': ingredients,
             'directions': directions,
+            'author': author,
             'image_src': urljoin(url, scraped_image),
             'servings': servings,
             'time': time,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
In order to populate author attribution, retrieve the `author` field from scraped recipe results.

### How have the changes been tested?
1. Unit test coverage is updated

**List any issues that this change relates to**
Relates to openculinary/backend#28.
Relates to openculinary/api#82.
Relates to openculinary/frontend#174.