### PR TITLE
[performance] Switch gunicorn to use gevent worker class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ image:
 	$(eval container=$(shell buildah from docker.io/library/python:3.8-alpine))
 	buildah copy $(container) 'web' 'web'
 	buildah copy $(container) 'Pipfile'
+	buildah run $(container) -- apk add py3-gevent --
 	buildah run $(container) -- apk add py3-lxml --
 	buildah run $(container) -- adduser -h /srv/ -s /sbin/nologin -D -H gunicorn --
 	buildah run $(container) -- chown gunicorn /srv/ --
@@ -40,7 +41,7 @@ image:
 	buildah run $(container) -- apk del libxslt-dev --
 	buildah run $(container) -- apk del musl-dev --
 	# End: NOTE
-	buildah config --port 8000 --user gunicorn --entrypoint '/srv/.local/bin/pipenv run gunicorn web.app:app --bind :8000' $(container)
+	buildah config --port 8000 --user gunicorn --env PYTHONPATH=/usr/lib/python3.8/site-packages --entrypoint '/srv/.local/bin/pipenv run gunicorn --worker-class gevent web.app:app --bind :8000' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}
 
 lint:

--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,6 @@ gunicorn = "==20.0.4"
 kubernetes = "==11.0.0"
 recipe-scrapers = "==9.2.4"
 requests = "==2.24.0"
-requests-futures = "==1.0.0"
 tldextract = "==2.2.2"
 
 [dev-packages]

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -79,21 +79,18 @@ def scrape_result():
 
 
 @patch('web.app.parse_ingredients')
-@patch('web.app.format_ingredients')
 @patch('web.app.parse_directions')
-@patch('web.app.format_directions')
 @patch('web.app.scrape_recipe')
 @patch('web.app.determine_image_version')
-def test_crawl_response(image_version, scrape_recipe, format_directions,
-                        parse_directions, format_ingredients,
+def test_crawl_response(image_version, scrape_recipe, parse_directions,
                         parse_ingredients, client, content_url, scrape_result):
     # HACK: Ensure that app initialization methods (re)run during this test
     app._got_first_request = False
 
     image_version.return_value = 'test_version'
     scrape_recipe.return_value = scrape_result
-    format_directions.return_value = ['test direction']
-    format_ingredients.return_value = ['test ingredient']
+    parse_directions.return_value = ['test direction']
+    parse_ingredients.return_value = ['test ingredient']
 
     response = client.post('/crawl', data={'url': content_url})
     metadata = response.json.get('metadata', {})


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Requests handled by the service tend to be network I/O bound, since they call external services to parse descriptive ingredient and direction text.

In order to increase the overall throughput of the system, this changeset updates `gunicorn` to use the `gevent` worker class since this is well-suited to environments where workloads are I/O bound.

### Briefly summarize the changes
1. Add the `py3-gevent` dependency to the container image
1. Run `gunicorn` using the `gevent` worker class

### How have the changes been tested?
1. Local development testing