### PR TITLE
Respect robots.txt during content retrieval

### DIFF
--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -139,3 +139,25 @@ def test_crawl_response(
     assert nutrition is not None
     assert nutrition['energy'] == 83.68
     assert nutrition['energy_units'] == 'J'
+
+
+@patch('web.app.scrape_recipe')
+@patch('web.app.can_fetch')
+def test_robots_txt_crawl_filtering(can_fetch, scrape_recipe, client):
+    can_fetch.return_value = False
+
+    response = client.post('/crawl', data={'url': content_url})
+
+    assert response.status_code == 403
+    assert not scrape_recipe.called
+
+
+@patch('requests.get')
+@patch('web.app.can_fetch')
+def test_robots_txt_resolution_filtering(can_fetch, get, client):
+    can_fetch.return_value = False
+
+    response = client.post('/resolve', data={'url': content_url})
+
+    assert response.status_code == 403
+    assert not get.called

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -31,7 +31,15 @@ def test_url_resolution_validation(image_version, client):
 
 @responses.activate
 @patch('web.app.determine_image_version')
-def test_origin_url_resolution(image_version, client, origin_url, content_url):
+@patch('web.app.can_fetch')
+def test_origin_url_resolution(
+    can_fetch,
+    image_version,
+    client,
+    origin_url,
+    content_url,
+):
+    can_fetch.return_value = True
     image_version.return_value = 'test_version'
     redir_headers = {'Location': content_url}
     responses.add(responses.GET, origin_url, status=301, headers=redir_headers)
@@ -90,11 +98,20 @@ def scrape_result():
 @patch('web.app.parse_descriptions')
 @patch('web.app.scrape_recipe')
 @patch('web.app.determine_image_version')
-def test_crawl_response(image_version, scrape_recipe, parse_descriptions,
-                        client, content_url, scrape_result):
+@patch('web.app.can_fetch')
+def test_crawl_response(
+    can_fetch,
+    image_version,
+    scrape_recipe,
+    parse_descriptions,
+    client,
+    content_url,
+    scrape_result,
+):
     # HACK: Ensure that app initialization methods (re)run during this test
     app._got_first_request = False
 
+    can_fetch.return_value = True
     image_version.return_value = 'test_version'
     scrape_recipe.return_value = scrape_result
     parse_descriptions.side_effect = [


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Respecting `robots.txt` is part of being a good netizen.

This pull request makes a start, by respecting binary can/cannot fetch logic per-URL (with per-domain caching).  This should bring us back into better standing given the relatively small volume of crawling that we do.

If our anticipated web crawling traffic is likely to increase, it may be worth adding support for the more-publisher-tunable [`request_rate`](https://github.com/python/cpython/blob/v3.9.2/Lib/urllib/robotparser.py#L193-L201) and [`crawl_delay`](https://github.com/python/cpython/blob/v3.9.2/Lib/urllib/robotparser.py#L183-L191) methods provided by Python's `robotparser` library.

### How have the changes been tested?
1. Test coverage is updated

**List any issues that this change relates to**
Resolves #21.