### PR TITLE
i18n: provide `language_code` argument to parsers

### DIFF
--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -112,6 +112,9 @@ def scrape_result():
         def yields(self):
             return "Makes 2"
 
+        def language(self):
+            return "en"
+
     return ScrapeResult()
 
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
To implement a fix for openculinary/quantity-parser#2 it would be useful for that service to know the natural language that the `descriptions[]` texts it is parsing are written in.

Fortunately, we can access language code information by using the existing `scraper.language()` field -- so we can retrieve information from there and pass it as a parameter to the relevant parsing service(s).

### Briefly summarize the changes
1. Extract `language` info from each recipe page scrape result retrieved by the crawler.
2. Provide contextual natural language information as a parameter to the parsing services.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
  * Supports openculinary/quantity-parser#2.
  * Provides data expected by:
    * openculinary/direction-parser#14
    * openculinary/ingredient-parser#31
    * openculinary/quantity-parser#3

Edit: add links to related pull requests in relevant downstream services.
Edit: remove word `resolve` found preceding a reference to a related issue, so that merging this pull request does not close it.