### PR TITLE
Netiquette: add an identifying HTTP user-agent for the crawler

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -7,12 +7,24 @@ from flask import Flask, request
 from tld import get_tld
 import requests
 from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
+from requests.utils import default_user_agent as requests_user_agent
 from robotexclusionrulesparser import RobotExclusionRulesParser
 
 from recipe_scrapers.__version__ import __version__ as rs_version
-from recipe_scrapers._abstract import HEADERS
 from recipe_scrapers._utils import get_yields
 from recipe_scrapers import WebsiteNotImplementedError, scrape_html
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 ("
+        "compatible; "
+        "Linux x86_64; "
+        f"{requests_user_agent()}; "
+        "RecipeRadar/0.1; "
+        "+https://www.reciperadar.com"
+        ")"
+    )
+}
 
 NUTRITION_SCHEMA_FIELDS = {
     "carbohydrates": "carbohydrateContent",


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This web crawler does respect `robots.txt` files, but the user-agent that it identifies itself with is fairly generic.  We should add something to identify that the source of the traffic is `RecipeRadar`.

Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent (particularly the [subsection regarding crawler user-agents](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#crawler_and_bot_ua_strings))

### Briefly summarize the changes
1. Add a user agent header that contains a generic compatibility note (`Mozilla/5.0`), some platform information (OS and current architecture), base client info (`requests` default user-agent) and crawler name with supporting informational URI.

### How have the changes been tested?
1. Unit tests are updated to match on the content of a token `RecipeRadar` within HTTP request `User-Agent` headers.
1. Local development testing.

**List any issues that this change relates to**
N/A

Edit: add more-precise reference hyperlink.