### PR TITLE
Improve freshness of cached robots.txt rules during recipe website crawling

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,6 +32,10 @@ blinker==1.9.0 \
     --hash=sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf \
     --hash=sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc
     # via flask
+cacheout==0.16.0 \
+    --hash=sha256:1a52d9aa8b1e9720d8453b061348f15795578231f9ec4ad376fec49e717d0ed8 \
+    --hash=sha256:ee264897cbaa089ae5f406da11952697d99fa7f3583cfab69fe8a00ff8e1952d
+    # via -r requirements.in
 certifi==2024.8.30 \
     --hash=sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8 \
     --hash=sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+cacheout==0.16.0
 flask==3.1.0
 gunicorn==23.0.0
 recipe-scrapers==15.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,10 @@ blinker==1.9.0 \
     --hash=sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf \
     --hash=sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc
     # via flask
+cacheout==0.16.0 \
+    --hash=sha256:1a52d9aa8b1e9720d8453b061348f15795578231f9ec4ad376fec49e717d0ed8 \
+    --hash=sha256:ee264897cbaa089ae5f406da11952697d99fa7f3583cfab69fe8a00ff8e1952d
+    # via -r requirements.in
 certifi==2024.8.30 \
     --hash=sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8 \
     --hash=sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -132,7 +132,7 @@ def scrape_result():
     return ScrapeResult()
 
 
-@patch("requests.get")
+@patch("requests.sessions.Session.get")
 @patch("web.app.parse_descriptions")
 @patch("web.app.scrape_html")
 @patch("web.app.can_fetch")
@@ -198,7 +198,7 @@ def test_robots_txt_crawl_filtering(can_fetch, scrape_html, client, content_url)
     assert not scrape_html.called
 
 
-@patch("requests.get")
+@patch("requests.sessions.Session.get")
 @patch("web.app.can_fetch")
 def test_robots_txt_resolution_filtering(can_fetch, get, client, content_url):
     can_fetch.return_value = False

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import re
 
 from dulwich import porcelain
@@ -26,6 +27,11 @@ def user_agent_matcher():
         "User-Agent": re.compile(r".*\bRecipeRadar\b.*"),
     }
     return matchers.header_matcher(expected_headers)
+
+
+@pytest.fixture
+def unproxied_matcher():
+    return matchers.request_kwargs_matcher({"proxies": OrderedDict()})
 
 
 def test_get_domain(origin_url):
@@ -210,8 +216,8 @@ def test_robots_txt_resolution_filtering(can_fetch, get, client, content_url):
 
 
 @responses.activate
-def test_get_robot_parser():
-    responses.get("https://example.test/robots.txt")
+def test_get_robot_parser(unproxied_matcher):
+    responses.get("https://example.test/robots.txt", match=[unproxied_matcher])
 
     target_url = "https://example.test/foo/bar"
     robot_parser = get_robot_parser(target_url)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The access rules configured in `robots.txt` files by recipe websites can change on a fairly frequent basis as sites adapt to traffic from robots/crawlers.

So far we have been using the same HTTP client -- one that will utilize a local Squid proxy cache -- to access `robots.txt` files as we would when accessing recipe webpages.  This means that we will have been using inappropriately-stale robots rules in many cases.

This pull request applies changes to limit the use of cached `robots.txt` rules.

### Briefly summarize the changes
1. When accessing `robots.txt` from recipe websites, use an HTTP client that bypasses the proxy cache.  We are doing this to improve adherence to recipe site crawling rules; it may marginally increase network traffic, but `robots.txt` files should, we hope, be small and inexpensive for websites to serve.
1. When storing an in-process cache of parsed `robots.txt` rules -- something that we do to reduce repeat/redundant network calls and improve performance -- add a 1-hour expiry to the in-process cache entry.

### How have the changes been tested?
1. Unit test coverage is provided.
2. Local development testing.

**List any issues that this change relates to**
Resolves #28.