### PR TITLE
Cleanup: remove recipe website images

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -229,22 +229,6 @@ def crawl():
         author = ", ".join(author)
 
     try:
-        scraped_image = scrape.image() or super(type(scrape), scrape).image()
-    except NotImplementedError:
-        return {
-            "error": {
-                "message": "image retrieval is not implemented",
-            }
-        }, 501
-
-    if not scraped_image:
-        return {
-            "error": {
-                "message": "could not find recipe image",
-            }
-        }, 404
-
-    try:
         language_code = scrape.language()
     except StaticValueException as static:
         language_code = static.return_value
@@ -350,7 +334,6 @@ def crawl():
             "ingredients": ingredients,
             "directions": directions,
             "author": author,
-            "image_src": urljoin(url, scraped_image),
             "nutrition": nutrition,
             "servings": servings,
             "time": time,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
After openculinary/backend#90, the [`backend`](https://github.com/openculinary/backend/) service does not store recipe image content any more.  As a result, we can remove the corresponding code here too.

### Briefly summarize the changes
1. Do not retrieve or require an `image` from each crawled recipe webpage.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Relates-to https://github.com/openculinary/backend/issues/89