### PR TITLE
Cleanup: do not retrieve recipe directions from webpages

### DIFF
--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -180,7 +180,6 @@ def test_crawl_response(
     scrape_html.return_value = scrape_result
     parse_descriptions.side_effect = [
         ["test ingredient"],
-        ["test direction"],
         [
             {"magnitude": 5, "units": "g"},
             {"magnitude": 83.68, "units": "J"},

--- a/web/app.py
+++ b/web/app.py
@@ -258,15 +258,6 @@ def crawl():
             }
         }, 404
 
-    instructions = scrape.instructions()
-    directions = parse_descriptions(
-        service="direction-parser-service",
-        language_code=language_code,
-        descriptions=(
-            instructions if isinstance(instructions, list) else instructions.split("\n")
-        ),
-    )
-
     time = scrape.total_time()
     if not time:
         return {
@@ -332,7 +323,6 @@ def crawl():
             "src": url,
             "domain": domain,
             "ingredients": ingredients,
-            "directions": directions,
             "author": author,
             "nutrition": nutrition,
             "servings": servings,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As described in https://github.com/openculinary/backend/issues/91 we do not currently make significant use of `directions` (aka instructions) text from recipes, however we do store a limited/filtered representation of the text in our database.  Despite that, we do initially retrieve the directions text.

Until we determine how to proceed safely here, it appears that there is some risk associated with retrieving complete directions text.  So let's not do that for now, and then revisit exactly what we want to achieve from the data and if/how we can achieve that.

### Briefly summarize the changes
1. Do not retrieve `directions` text from each recipe webpage during crawling.

### How have the changes been tested?
1. Test coverage is updated.

**List any issues that this change relates to**
Relates to https://github.com/openculinary/backend/issues/91