### PR TITLE
Crawling: add per-domain 'cache' and 'crawl' configuration

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -103,10 +103,31 @@ def get_robot_parser(url):
     return domain_robot_parsers.get(domain)
 
 
+def get_domain_configuration(domain):
+    response = microservice_client.get(
+        url=f"http://backend-service/domains/{domain}",
+        proxies={},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def can_crawl(domain_config):
+    if domain_config.get("crawl_enabled") is False:
+        return False
+    return True
+
+
 def can_fetch(url):
     robot_parser = get_robot_parser(url)
     user_agent = HEADERS.get("User-Agent", "*")
     return robot_parser.is_allowed(user_agent, url)
+
+
+def can_cache(domain_config):
+    if domain_config.get("cache_enabled") is False:
+        return False
+    return True
 
 
 @app.route("/resolve", methods=["POST"])
@@ -126,7 +147,26 @@ def resolve():
             }
         }, 403
 
-    response = proxy_cache_client.get(url, headers=HEADERS, timeout=5)
+    domain = get_domain(url)
+    try:
+        domain_config = get_domain_configuration(domain)
+    except Exception:
+        return {
+            "error": {
+                "message": f"unable to retrieve {url} domain configuration",
+            }
+        }, 500
+
+    if not can_crawl(domain_config):
+        return {
+            "error": {
+                "message": f"url resolution of {url} disallowed by configuration",
+            }
+        }, 403
+
+    domain_http_client = proxy_cache_client if can_cache(domain_config) else web_client
+
+    response = domain_http_client.get(url, headers=HEADERS, timeout=5)
     if not response.ok:
         return {
             "error": {
@@ -174,6 +214,22 @@ def crawl():
         }, 403
 
     domain = get_domain(url)
+    try:
+        domain_config = get_domain_configuration(domain)
+    except Exception:
+        return {
+            "error": {
+                "message": f"unable to retrieve {url} domain configuration",
+            }
+        }, 500
+
+    if not can_crawl(domain_config):
+        return {
+            "error": {
+                "message": f"crawling {url} disallowed by configuration",
+            }
+        }, 403
+
     if domain in domain_backoffs:
         start = domain_backoffs[domain]["timestamp"]
         duration = domain_backoffs[domain]["duration"]
@@ -187,8 +243,9 @@ def crawl():
                 }
             }, 429
 
+    domain_http_client = proxy_cache_client if can_cache(domain_config) else web_client
     try:
-        response = proxy_cache_client.get(url, headers=HEADERS, timeout=5)
+        response = domain_http_client.get(url, headers=HEADERS, timeout=5)
         response.raise_for_status()
         scrape = scrape_html(response.text, response.url)
     except HTTPError:


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Some websites state in their terms and conditions that web crawling for the purpose of indexing into public web search engines is acceptable, provided that the resulting content is not cached.  To accommodate that, this changeset adds logic to obey a configuration setting we recently implemented in https://github.com/openculinary/backend/pull/93 

### Briefly summarize the changes
1. Add logic to obey the `cache_enabled` configuration setting provided by the [`backend` service](https://github.com/openculinary/backend/).
1. Because it adds minimal code complexity and also adds an additional safety-check beyond the [existing code in the `backend` recipe crawler worker](https://github.com/openculinary/backend/blob/5d3214df56f896f69d93b6a80ab433b33d50f16c/reciperadar/workers/recipes.py#L193-L197), additionally add logic to respect the `crawl_enabled` flag.

### How have the changes been tested?
1. Unit test coverage is provided.

**List any issues that this change relates to**
Resolves #31.