### PR TITLE
Add logic to respect the HTTP 'Retry-After' header during crawling

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,28 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from web.parsing import parse_retry_duration
+
+
+@pytest.mark.parametrize(
+    "retry_after, expected_duration",
+    [
+        ("5", 5),
+        ("5.4", 6),
+        (
+            "Fri, 2 Jan 1970 03:04 -0500",
+            (24 * 60 * 60) + (3 * 60 * 60) + (4 * 60) + (5 * 60 * 60),
+        ),
+        (
+            "Fri, 2 Jan 1970 03:04 -0000",
+            (24 * 60 * 60) + (3 * 60 * 60) + (4 * 60),
+        ),
+    ],
+)
+def test_parse_retry_duration(retry_after, expected_duration):
+    from_moment = datetime(1970, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+    duration = parse_retry_duration(from_moment, retry_after)
+
+    assert duration == expected_duration

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -170,7 +170,7 @@ def test_fetch_endpoints_respect_server_backoff(
     responses.get(
         origin_url,
         status=503,
-        headers={"Retry-After": "3600"},
+        headers={"Retry-After": "0.1"},
     )
 
     response = client.post(f"/{endpoint}", data={"url": origin_url})

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -170,7 +170,7 @@ def test_fetch_endpoints_respect_server_backoff(
     responses.get(
         origin_url,
         status=503,
-        headers={"Retry-After": "0.1"},
+        headers={"Retry-After": "3600"},
     )
 
     response = client.post(f"/{endpoint}", data={"url": origin_url})

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -8,12 +8,17 @@ from requests import ReadTimeout
 from responses import matchers
 from recipe_scrapers import StaticValueException
 
-from web.app import app, get_domain
+from web.app import app, domain_backoffs, get_domain
 
 
 @pytest.fixture
-def origin_url():
-    return "https://recipe.subdomain.example.test/recipe/123"
+def origin_domain():
+    return "example.test"
+
+
+@pytest.fixture
+def origin_url(origin_domain):
+    return f"https://recipe.subdomain.{origin_domain}/recipe/123"
 
 
 @pytest.fixture
@@ -142,6 +147,38 @@ def test_fetch_endpoints_timeout_backoff(
     assert error is not None
     assert "adding backoff" in error["message"]
     assert "url" not in response.json
+
+
+@responses.activate
+@pytest.mark.parametrize("endpoint", ["resolve", "crawl"])
+@patch.dict(domain_backoffs, clear=True)
+@patch("web.app.can_fetch")
+def test_fetch_endpoints_respect_server_backoff(
+    can_fetch,
+    client,
+    origin_domain,
+    origin_url,
+    endpoint,
+):
+    can_fetch.return_value = True
+    assert len(domain_backoffs) == 0
+
+    responses.get(
+        "http://backend-service/domains/example.test",
+        json={},
+    )
+    responses.get(
+        origin_url,
+        status=503,
+        headers={"Retry-After": "3600"},
+    )
+
+    response = client.post(f"/{endpoint}", data={"url": origin_url})
+    error = response.json.get("error")
+
+    assert error is not None
+    assert "url" not in response.json
+    assert origin_domain in domain_backoffs
 
 
 @pytest.fixture

--- a/web/app.py
+++ b/web/app.py
@@ -121,7 +121,12 @@ def crawl():
         message = f"timeout; adding backoff for {domain}"
         return {"error": {"message": message}}, 429
     finally:
-        sleep(retry_duration)
+        if retry_duration:
+            existing_duration = domain_backoffs.get(domain, {}).get("duration") or 0
+            domain_backoffs[domain] = {
+                "timestamp": datetime.now(tz=UTC),
+                "duration": max(existing_duration, retry_duration),
+            }
 
     return {
         "metadata": _service_metadata(),

--- a/web/web_clients.py
+++ b/web/web_clients.py
@@ -1,4 +1,6 @@
+from datetime import UTC, datetime
 import ssl
+from time import sleep
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -33,8 +35,22 @@ class ProxyCacheHTTPAdapter(HTTPAdapter):
         return params
 
 
+class DelayableRedirectSession(requests.Session):
+
+    def resolve_redirects(self, response, *args, **kwargs):
+        from web.parsing import parse_retry_duration
+
+        if "Retry-After" in response.headers:
+            duration = parse_retry_duration(
+                from_moment=datetime.now(tz=UTC),
+                retry_after=response.headers["Retry-After"],
+            )
+            sleep(duration)
+        yield from super().resolve_redirects(response, *args, **kwargs)
+
+
 microservice_client = requests.Session()
-proxy_cache_client = requests.Session()
+proxy_cache_client = DelayableRedirectSession()
 proxy_cache_client.proxies.update(
     {
         "http": "http://proxy:3128",
@@ -42,7 +58,7 @@ proxy_cache_client.proxies.update(
     }
 )
 proxy_cache_client.mount("https://", ProxyCacheHTTPAdapter())
-web_client = requests.Session()
+web_client = DelayableRedirectSession()
 
 
 def select_client(domain):

--- a/web/web_clients.py
+++ b/web/web_clients.py
@@ -40,7 +40,7 @@ class DelayableRedirectSession(requests.Session):
     def resolve_redirects(self, response, *args, **kwargs):
         from web.parsing import parse_retry_duration
 
-        if "Retry-After" in response.headers:
+        if response.is_redirect and "Retry-After" in response.headers:
             duration = parse_retry_duration(
                 from_moment=datetime.now(tz=UTC),
                 retry_after=response.headers["Retry-After"],


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
HTTP servers may include a [`Retry-After` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) in their responses to indicate that the client should not expect (or attempt to retrieve) a response until after a number of seconds or a specified date.

So far the crawler here has not checked for and delayed crawls based on the presence of that header in HTTP responses; this changeset adds logic to do so.

### Briefly summarize the changes
1. When a non-success HTTP response is received, check for a `Retry-After` response header.
1. If a `Retry-After` response header is found, parse the contents as a number of seconds or a future date, and return a number of seconds that the crawler should wait.
1. Add a ~~`sleep`~~ domain crawling delay backoff of the relevant number of seconds following each request.

### How have the changes been tested?
1. Unit test coverage is provided.
1. Development/production testing is pending.

**List any issues that this change relates to**
Resolves #35.

Edit: adjust description; the logic no longer sleeps mid-request but instead adds a domain backoff delay.