### PR TITLE
Fixup: add per-domain backoff logic to 'resolve' API endpoint

### DIFF
--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -120,7 +120,7 @@ def test_error_url_resolution(
 @responses.activate
 @pytest.mark.parametrize("endpoint", ["resolve", "crawl"])
 @patch("web.app.can_fetch")
-def test_fetch_endpoints_respect_server_backoff(
+def test_fetch_endpoints_timeout_backoff(
     can_fetch,
     client,
     origin_url,

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -134,7 +134,6 @@ def test_fetch_endpoints_timeout_backoff(
     responses.get(
         origin_url,
         body=ReadTimeout(),
-        headers={"Retry-After": "3600"},
     )
 
     response = client.post(f"/{endpoint}", data={"url": origin_url})


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Within the `/crawl` API endpoint, we add per-domain backoffs when certain types of error/failure occur.  Soon we will expand this with the changes from #38 to include server-communicated delay requests (the HTTP `Retry-After` response header).

We should apply the same logic within the `/resolve` API endpoint, because from the perspective of the webserver the traffic is likely to appear very similar if not identical.

### Briefly summarize the changes
1. Ensure that both `/resolve` and `/crawl` endpoints add per-domain backoffs in a consistent way.

### How have the changes been tested?
1. ~~Testing is pending.~~ Unit test coverage is provided.

**List any issues that this change relates to**
Resolves #39.