### PR TITLE
Add logic to respect the robots.txt 'Crawl-Delay' directive

### DIFF
--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -1,6 +1,6 @@
 import responses
 
-from web.robots import get_robot_parser
+from web.robots import get_robot_parser, can_fetch, crawl_delay, domain_robot_parsers
 
 
 @responses.activate
@@ -12,3 +12,46 @@ def test_get_robot_parser(unproxied_matcher):
 
     assert robot_parser is not None
     assert robot_parser.is_allowed("*", target_url)
+
+
+@responses.activate
+def test_can_fetch():
+    domain_robot_parsers.clear()  # TODO: implicit cache teardown
+    responses.get(
+        "https://example.test/robots.txt",
+        body="\n".join(
+            [
+                "User-agent: RecipeRadar",
+                "Disallow: /recipes/private/*",
+                "Allow: /recipes/*",
+                "Disallow: *",
+            ]
+        ),
+    )
+
+    statistics_allowed = can_fetch("https://example.test/statistics")
+    public_recipe_allowed = can_fetch("https://example.test/recipes/example")
+    private_recipe_allowed = can_fetch("https://example.test/recipes/private/other")
+
+    assert statistics_allowed is False
+    assert public_recipe_allowed is True
+    assert private_recipe_allowed is False
+
+
+@responses.activate
+def test_get_crawl_delay():
+    domain_robot_parsers.clear()  # TODO: implicit cache teardown
+    responses.get(
+        "https://example.test/robots.txt",
+        body="\n".join(
+            [
+                "User-agent: reciperadar",
+                "Crawl-delay: 5",
+            ]
+        ),
+    )
+
+    target_url = "https://example.test/foo/bar"
+    delay = crawl_delay(target_url)
+
+    assert delay == 5

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -10,6 +10,7 @@ from responses import matchers
 from recipe_scrapers import StaticValueException
 
 from web.app import app, domain_backoffs, get_domain
+from web.robots import domain_robot_parsers
 
 
 @pytest.fixture
@@ -29,6 +30,7 @@ def content_url(origin_url):
 
 @pytest.fixture
 def permissive_robots_txt(origin_url, content_url):
+    domain_robot_parsers.clear()
     robots_txts = {
         urljoin(origin_url, "/robots.txt"),
         urljoin(content_url, "/robots.txt"),

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -271,13 +271,12 @@ def scrape_result():
     return ScrapeResult()
 
 
-@patch("requests.sessions.Session.get")
+@responses.activate
 @patch("web.parsing.parse_descriptions")
 @patch("web.parsing.scrape_html")
 def test_crawl_response(
     scrape_html,
     parse_descriptions,
-    get,
     client,
     permissive_robots_txt,
     content_url,
@@ -285,6 +284,15 @@ def test_crawl_response(
 ):
     # HACK: Ensure that app initialization methods (re)run during this test
     app._got_first_request = False
+
+    responses.get(
+        "http://backend-service/domains/example.test",
+        json={},
+    )
+    responses.get(
+        content_url,
+        status=200,
+    )
 
     scrape_html.return_value = scrape_result
     parse_descriptions.side_effect = [

--- a/web/app.py
+++ b/web/app.py
@@ -13,7 +13,7 @@ from web.exceptions import (
     DomainCrawlProhibited,
 )
 from web.parsing import parse_retry_duration, scrape_recipe, scrape_canonical_url
-from web.robots import can_fetch
+from web.robots import can_fetch, crawl_delay
 from web.web_clients import select_client
 
 app = Flask(__name__)
@@ -57,6 +57,10 @@ def resolve():
             sleep(duration.seconds)
             message = f"backing off for {domain}"
             return {"error": {"message": message}}, 429
+
+    delay = crawl_delay(url)
+    if delay:
+        sleep(delay)
 
     retry_duration = 0
     try:
@@ -132,6 +136,10 @@ def crawl():
             sleep(duration.seconds)
             message = f"backing off for {domain}"
             return {"error": {"message": message}}, 429
+
+    delay = crawl_delay(url)
+    if delay:
+        sleep(delay)
 
     retry_duration = 0
     try:

--- a/web/robots.py
+++ b/web/robots.py
@@ -21,8 +21,8 @@ class _PatchedRuleset(_Ruleset):
     def is_not_empty(self):
         return _PatchedRuleset._is_not_empty(self) or self.crawl_delay is not None
 
-_Ruleset.is_not_empty = _PatchedRuleset.is_not_empty
 
+_Ruleset.is_not_empty = _PatchedRuleset.is_not_empty
 
 
 def get_robot_parser(url):

--- a/web/robots.py
+++ b/web/robots.py
@@ -28,3 +28,9 @@ def can_fetch(url):
     robot_parser = get_robot_parser(url)
     user_agent = HEADERS_DEFAULT.get("User-Agent", "*")
     return robot_parser.is_allowed(user_agent, url)
+
+
+def crawl_delay(url):
+    robot_parser = get_robot_parser(url)
+    user_agent = HEADERS_DEFAULT.get("User-Agent", "*")
+    return robot_parser.get_crawl_delay(user_agent) or 0

--- a/web/robots.py
+++ b/web/robots.py
@@ -3,7 +3,7 @@ from urllib.parse import urljoin
 
 from cacheout import Cache
 import requests
-from robotexclusionrulesparser import RobotExclusionRulesParser
+from robotexclusionrulesparser import RobotExclusionRulesParser, _Ruleset
 
 from web.domains import get_domain
 from web.web_clients import HEADERS_DEFAULT
@@ -12,6 +12,17 @@ web_client = requests.Session()
 
 
 domain_robot_parsers = Cache(ttl=60 * 60, timer=time)  # 1hr cache expiry
+
+
+# Workaround: recognize robots.txt rulesets containining solely a crawl-delay.
+class _PatchedRuleset(_Ruleset):
+    _is_not_empty = _Ruleset.is_not_empty
+
+    def is_not_empty(self):
+        return _PatchedRuleset._is_not_empty(self) or self.crawl_delay is not None
+
+_Ruleset.is_not_empty = _PatchedRuleset.is_not_empty
+
 
 
 def get_robot_parser(url):

--- a/web/robots.py
+++ b/web/robots.py
@@ -44,4 +44,4 @@ def can_fetch(url):
 def crawl_delay(url):
     robot_parser = get_robot_parser(url)
     user_agent = HEADERS_DEFAULT.get("User-Agent", "*")
-    return robot_parser.get_crawl_delay(user_agent) or 0
+    return max(1, robot_parser.get_crawl_delay(user_agent) or 0)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Although seemingly inconsistently specified, the `robots.txt` format does include a `Crawl-Delay` directive intended to instruct crawlers about how long to wait, in seconds, between web crawling requests.  To improve our netiquette we should obey this directive when we crawling recipe websites.

TODO: confirm that we are retrieving `robots.txt` from the subdomain of matching URL, and not the TLD (e.g. if requesting a page from `//foo.bar.example.test`, we should retrieve `//foo.bar.example.test/robots.txt`, _not_ `//example.test/robots.txt`).

TODO: Report the `robotexclusionrulesparser` bug somewhere?  On initial inspection it does not appear to be an actively maintained library.

### Briefly summarize the changes
1. Add a `web.robots.crawl_delay` function that retrieves-or-reuses the parsed `robots.txt` rules for a given domain, and extracts the crawl delay, if any, for the crawler's user agent.  The returned value, a delay in integer seconds, is `>=1`.
1. Add a workaround for a quirk in the version of the [`robotexclusionrulesparser` library](https://github.com/openculinary/crawler/blob/e97c0abcefa19eeda5741cb7d89ee29887c290ef/requirements.in#L6) that we use: a ruleset containing solely a `Crawl-Delay` and no allow/disallow/other rules is not recognized.

### How have the changes been tested?
1. Unit test coverage is provided.

**List any issues that this change relates to**
Resolves #36.