### PR TITLE
Migration: access configuration and 'robots.txt' per-domain not per-TLD

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -603,10 +603,6 @@ soupsieve==2.6 \
     --hash=sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb \
     --hash=sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9
     # via beautifulsoup4
-tld==0.13 \
-    --hash=sha256:93dde5e1c04bdf1844976eae440706379d21f4ab235b73c05d7483e074fb5629 \
-    --hash=sha256:f75b2be080f767ed17c2338a339eaa4fab5792586319ca819119da252f9f3749
-    # via -r requirements.in
 urllib3==2.2.3 \
     --hash=sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac \
     --hash=sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9

--- a/requirements.in
+++ b/requirements.in
@@ -4,4 +4,3 @@ gunicorn==23.0.0
 recipe-scrapers==15.3.3
 requests[use_chardet_on_py3]==2.32.3
 robotexclusionrulesparser==1.7.1
-tld==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -430,10 +430,6 @@ soupsieve==2.6 \
     --hash=sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb \
     --hash=sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9
     # via beautifulsoup4
-tld==0.13 \
-    --hash=sha256:93dde5e1c04bdf1844976eae440706379d21f4ab235b73c05d7483e074fb5629 \
-    --hash=sha256:f75b2be080f767ed17c2338a339eaa4fab5792586319ca819119da252f9f3749
-    # via -r requirements.in
 urllib3==2.2.3 \
     --hash=sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac \
     --hash=sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,8 @@
 from collections import OrderedDict
-from unittest.mock import patch
 
 import pytest
 
 from responses import matchers
-from tld import get_tld, get_tld_names, update_tld_names
 
 from web.app import app
 
@@ -12,24 +10,6 @@ from web.app import app
 @pytest.fixture
 def client():
     return app.test_client()
-
-
-@pytest.fixture(autouse=True)
-def patch_get_tld():
-    with patch("web.domains.get_tld") as mock_get_tld:
-        # Add private/reserved .test TLD
-        for local_path, domain_trie in get_tld_names().items():
-            domain_trie.add("test", private=True)
-            update_tld_names(local_path, domain_trie)
-
-        # Passthrough get_tld queries with private-TLD search enabled
-        def get_tld_private_enabled(*args, **kwargs):
-            kwargs["search_private"] = True
-            return get_tld(*args, **kwargs)
-
-        # Return the passthrough get_tld
-        mock_get_tld.side_effect = get_tld_private_enabled
-        yield mock_get_tld
 
 
 @pytest.fixture

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -15,12 +15,12 @@ from web.robots import domain_robot_parsers
 
 @pytest.fixture
 def origin_domain():
-    return "example.test"
+    return "recipe.subdomain.example.test"
 
 
 @pytest.fixture
 def origin_url(origin_domain):
-    return f"https://recipe.subdomain.{origin_domain}/recipe/123"
+    return f"https://{origin_domain}/recipe/123"
 
 
 @pytest.fixture
@@ -56,7 +56,7 @@ def nostore_matcher():
 def test_get_domain(origin_url):
     domain = get_domain(origin_url)
 
-    assert domain == "example.test"
+    assert domain == "recipe.subdomain.example.test"
 
 
 def test_url_resolution_validation(client):
@@ -76,7 +76,7 @@ def test_origin_url_resolution(
 ):
     headers = {"Location": content_url}
     responses.get(
-        "http://backend-service/domains/example.test",
+        "http://backend-service/domains/recipe.subdomain.example.test",
         json={},
     )
     responses.get(
@@ -115,7 +115,7 @@ def test_error_url_resolution(
     content_url,
 ):
     responses.get(
-        "http://backend-service/domains/example.test",
+        "http://backend-service/domains/recipe.subdomain.example.test",
         json={},
     )
     responses.get(
@@ -140,7 +140,7 @@ def test_fetch_endpoints_timeout_backoff(
     endpoint,
 ):
     responses.get(
-        "http://backend-service/domains/example.test",
+        "http://backend-service/domains/recipe.subdomain.example.test",
         json={},
     )
     responses.get(
@@ -169,7 +169,7 @@ def test_fetch_endpoints_respect_server_backoff(
     assert len(domain_backoffs) == 0
 
     responses.get(
-        "http://backend-service/domains/example.test",
+        "http://backend-service/domains/recipe.subdomain.example.test",
         json={},
     )
     responses.get(
@@ -202,7 +202,7 @@ def test_fetch_endpoints_respect_server_redirect_backoff(
     assert len(domain_backoffs) == 0
 
     responses.get(
-        "http://backend-service/domains/example.test",
+        "http://backend-service/domains/recipe.subdomain.example.test",
         json={},
     )
     responses.get(
@@ -286,7 +286,7 @@ def test_crawl_response(
     app._got_first_request = False
 
     responses.get(
-        "http://backend-service/domains/example.test",
+        "http://backend-service/domains/recipe.migrated.example.test",
         json={},
     )
     responses.get(
@@ -357,7 +357,7 @@ def test_robots_txt_resolution_filtering(can_fetch, get, client, content_url):
 @patch("web.parsing.scrape_html")
 def test_domain_config_unavailable_not_crawled(scrape_html, client, content_url):
     responses.get(
-        "http://backend-service/domains/example.test",
+        "http://backend-service/domains/recipe.subdomain.example.test",
         status=500,
     )
 
@@ -370,7 +370,7 @@ def test_domain_config_unavailable_not_crawled(scrape_html, client, content_url)
 @patch("web.parsing.scrape_html")
 def test_http_crawl_disabled_not_crawled(scrape_html, client, content_url):
     responses.get(
-        "http://backend-service/domains/example.test",
+        "http://backend-service/domains/recipe.subdomain.example.test",
         json={"crawl_enabled": False},
     )
 
@@ -389,7 +389,7 @@ def test_http_cache_disabled_direct_access(
     content_url,
 ):
     responses.get(
-        "http://backend-service/domains/example.test",
+        "http://backend-service/domains/recipe.migrated.example.test",
         json={"cache_enabled": False},
     )
     responses.get(
@@ -412,7 +412,10 @@ def test_http_error_not_crawled(
     cache_proxy_matcher,
     content_url,
 ):
-    responses.get("http://backend-service/domains/example.test", json={})
+    responses.get(
+        "http://backend-service/domains/recipe.migrated.example.test",
+        json={},
+    )
     responses.get(
         content_url,
         status=404,

--- a/web/domains.py
+++ b/web/domains.py
@@ -1,4 +1,4 @@
-from tld import get_tld
+from urllib.parse import urlparse
 
 from web.web_clients import microservice_client
 
@@ -6,8 +6,7 @@ domain_backoffs = {}
 
 
 def get_domain(url):
-    url_info = get_tld(url, as_object=True, search_private=False)
-    return url_info.fld
+    return urlparse(url).netloc
 
 
 def get_domain_configuration(domain):


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The motivation for this changeset is that `robots.txt` should be retrieved and considered on a per-web-domain basis, not a per-TLD basis as we have mistakenly been using so far.

Querying our `domains` database table identified that per-domain configuration of recipe websites should have very minimal impact on operational management of recipe webcrawling configuration -- and so we migrate to use domains instead of TLDs for crawler configuration in this changeset too.

### Briefly summarize the changes
1. Adjust the `get_domain` function -- used for both `robots.txt` cache key and also web crawler configuration access -- to return the host domain, that may potentially be a subdomain, instead of the top-level domain of each input URL.
1. Remove the `tld` library dependency.

### How have the changes been tested?
1. Unit test coverage is updated.

**List any issues that this change relates to**
Resolves #42.