### PR TITLE
Allow proxy-cached HTTP client for 'robots.txt' retrieval

### DIFF
--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -4,8 +4,9 @@ from web.robots import get_robot_parser, can_fetch, crawl_delay, domain_robot_pa
 
 
 @responses.activate
-def test_get_robot_parser(unproxied_matcher):
-    responses.get("https://example.test/robots.txt", match=[unproxied_matcher])
+def test_get_robot_parser():
+    responses.get("http://backend-service/domains/example.test", json={})
+    responses.get("https://example.test/robots.txt")
 
     target_url = "https://example.test/foo/bar"
     robot_parser = get_robot_parser(target_url)
@@ -17,6 +18,7 @@ def test_get_robot_parser(unproxied_matcher):
 @responses.activate
 def test_can_fetch():
     domain_robot_parsers.clear()  # TODO: implicit cache teardown
+    responses.get("http://backend-service/domains/example.test", json={})
     responses.get(
         "https://example.test/robots.txt",
         body="\n".join(
@@ -41,6 +43,7 @@ def test_can_fetch():
 @responses.activate
 def test_get_crawl_delay():
     domain_robot_parsers.clear()  # TODO: implicit cache teardown
+    responses.get("http://backend-service/domains/example.test", json={})
     responses.get(
         "https://example.test/robots.txt",
         body="\n".join(

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -331,9 +331,14 @@ def test_crawl_response(
     assert language == "en"
 
 
+@responses.activate(assert_all_requests_are_fired=True)
 @patch("web.parsing.scrape_html")
 @patch("web.app.can_fetch")
 def test_robots_txt_crawl_filtering(can_fetch, scrape_html, client, content_url):
+    responses.get(
+        "http://backend-service/domains/recipe.migrated.example.test",
+        json={},
+    )
     can_fetch.return_value = False
 
     response = client.post("/crawl", data={"url": content_url})
@@ -342,15 +347,18 @@ def test_robots_txt_crawl_filtering(can_fetch, scrape_html, client, content_url)
     assert not scrape_html.called
 
 
-@patch("requests.sessions.Session.get")
+@responses.activate(assert_all_requests_are_fired=True)
 @patch("web.app.can_fetch")
-def test_robots_txt_resolution_filtering(can_fetch, get, client, content_url):
+def test_robots_txt_resolution_filtering(can_fetch, client, content_url):
+    responses.get(
+        "http://backend-service/domains/recipe.migrated.example.test",
+        json={},
+    )
     can_fetch.return_value = False
 
     response = client.post("/resolve", data={"url": content_url})
 
     assert response.status_code == 403
-    assert not get.called
 
 
 @responses.activate

--- a/web/app.py
+++ b/web/app.py
@@ -34,10 +34,6 @@ def resolve():
         message = "url parameter is required"
         return {"error": {"message": message}}, 400
 
-    if not can_fetch(url):
-        message = f"crawling {url} disallowed by robots.txt"
-        return {"error": {"message": message}}, 403
-
     domain = get_domain(url)
     try:
         domain_http_client, headers = select_client(domain)
@@ -46,6 +42,10 @@ def resolve():
         return {"error": {"message": message}}, 500
     except DomainCrawlProhibited:
         message = f"url resolution of {url} disallowed by configuration"
+        return {"error": {"message": message}}, 403
+
+    if not can_fetch(url):
+        message = f"crawling {url} disallowed by robots.txt"
         return {"error": {"message": message}}, 403
 
     if domain in domain_backoffs:
@@ -113,10 +113,6 @@ def crawl():
         message = "url parameter is required"
         return {"error": {"message": message}}, 400
 
-    if not can_fetch(url):
-        message = f"crawling {url} disallowed by robots.txt"
-        return {"error": {"message": message}}, 403
-
     domain = get_domain(url)
     try:
         domain_http_client, headers = select_client(domain)
@@ -125,6 +121,10 @@ def crawl():
         return {"error": {"message": message}}, 500
     except DomainCrawlProhibited:
         message = f"crawling {url} disallowed by configuration"
+        return {"error": {"message": message}}, 403
+
+    if not can_fetch(url):
+        message = f"crawling {url} disallowed by robots.txt"
         return {"error": {"message": message}}, 403
 
     if domain in domain_backoffs:

--- a/web/robots.py
+++ b/web/robots.py
@@ -2,13 +2,10 @@ from time import time
 from urllib.parse import urljoin
 
 from cacheout import Cache
-import requests
 from robotexclusionrulesparser import RobotExclusionRulesParser, _Ruleset
 
 from web.domains import get_domain
-from web.web_clients import HEADERS_DEFAULT
-
-web_client = requests.Session()
+from web.web_clients import HEADERS_DEFAULT, select_client
 
 
 domain_robot_parsers = Cache(ttl=60 * 60, timer=time)  # 1hr cache expiry
@@ -27,9 +24,13 @@ _Ruleset.is_not_empty = _PatchedRuleset.is_not_empty
 
 def get_robot_parser(url):
     domain = get_domain(url)
+    domain_http_client, headers = select_client(domain)
     if domain not in domain_robot_parsers:
         robot_parser = RobotExclusionRulesParser()
-        robots_txt = web_client.get(urljoin(url, "/robots.txt"))
+        robots_txt = domain_http_client.get(
+            urljoin(url, "/robots.txt"),
+            headers=headers,
+        )
         robot_parser.parse(robots_txt.content)
         domain_robot_parsers.set(domain, robot_parser)
     return domain_robot_parsers.get(domain)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Removes a special-case -- that all `robots.txt` HTTP retrieval requests, regardless of domain configuration, used a non-caching HTTP path.

Additionally, relocate the `can_fetch` conditional check -- that will access `robots.txt` when it is not cached locally -- until after the domain's local configuration in our operational database has been checked.

These are simplifications intended to make it easier to manage and/or disable all outbound HTTP traffic (including `robots.txt` requests) from our crawler on a per-domain basis.

### Briefly summarize the changes
1. Consistently refer to [`backend`](https://github.com/openculinary/backend/) domain configuration before accessing either `robots.txt` or recipe webpage content.
1. Consistently use either proxy-cached or direct traffic before accessing either a domain's `robots.txt` file and/or its recipe webpages.

### How have the changes been tested?
1. Unit test coverage is updated.

**List any issues that this change relates to**
Resolves #43.