### PR TITLE
Crawling: use same User-Agent header during 'robots.txt' retrieval as recipe webpage retrieval

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import re
 
 import pytest
 
@@ -10,6 +11,14 @@ from web.app import app
 @pytest.fixture
 def client():
     return app.test_client()
+
+
+@pytest.fixture
+def user_agent_matcher():
+    expected_headers = {
+        "User-Agent": re.compile(r".*\bRecipeRadar\b.*"),
+    }
+    return matchers.header_matcher(expected_headers)
 
 
 @pytest.fixture

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -1,5 +1,4 @@
 import responses
-from responses import matchers
 
 from web.robots import get_robot_parser, can_fetch, crawl_delay, domain_robot_parsers
 
@@ -9,7 +8,7 @@ def test_get_robot_parser(user_agent_matcher, unproxied_matcher):
     responses.get("http://backend-service/domains/example.test", json={})
     responses.get(
         "https://example.test/robots.txt",
-        match=[user_agent_matcher, unproxied_matcher]
+        match=[user_agent_matcher, unproxied_matcher],
     )
 
     target_url = "https://example.test/foo/bar"

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -1,11 +1,16 @@
 import responses
+from responses import matchers
 
 from web.robots import get_robot_parser, can_fetch, crawl_delay, domain_robot_parsers
 
 
 @responses.activate
-def test_get_robot_parser(unproxied_matcher):
-    responses.get("https://example.test/robots.txt", match=[unproxied_matcher])
+def test_get_robot_parser(user_agent_matcher, unproxied_matcher):
+    responses.get("http://backend-service/domains/example.test", json={})
+    responses.get(
+        "https://example.test/robots.txt",
+        match=[user_agent_matcher, unproxied_matcher]
+    )
 
     target_url = "https://example.test/foo/bar"
     robot_parser = get_robot_parser(target_url)
@@ -15,8 +20,9 @@ def test_get_robot_parser(unproxied_matcher):
 
 
 @responses.activate
-def test_can_fetch():
+def test_can_fetch(user_agent_matcher):
     domain_robot_parsers.clear()  # TODO: implicit cache teardown
+    responses.get("http://backend-service/domains/example.test", json={})
     responses.get(
         "https://example.test/robots.txt",
         body="\n".join(
@@ -27,6 +33,7 @@ def test_can_fetch():
                 "Disallow: *",
             ]
         ),
+        match=[user_agent_matcher],
     )
 
     statistics_allowed = can_fetch("https://example.test/statistics")
@@ -39,8 +46,9 @@ def test_can_fetch():
 
 
 @responses.activate
-def test_get_crawl_delay():
+def test_get_crawl_delay(user_agent_matcher):
     domain_robot_parsers.clear()  # TODO: implicit cache teardown
+    responses.get("http://backend-service/domains/example.test", json={})
     responses.get(
         "https://example.test/robots.txt",
         body="\n".join(
@@ -49,6 +57,7 @@ def test_get_crawl_delay():
                 "Crawl-delay: 5",
             ]
         ),
+        match=[user_agent_matcher],
     )
 
     target_url = "https://example.test/foo/bar"

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,4 +1,3 @@
-import re
 from urllib.parse import urljoin
 from unittest.mock import patch
 
@@ -37,14 +36,6 @@ def permissive_robots_txt(origin_url, content_url):
     }
     for robots_txt in robots_txts:
         responses.get(robots_txt, body="User-agent: *\nAllow: *\n")
-
-
-@pytest.fixture
-def user_agent_matcher():
-    expected_headers = {
-        "User-Agent": re.compile(r".*\bRecipeRadar\b.*"),
-    }
-    return matchers.header_matcher(expected_headers)
 
 
 @pytest.fixture

--- a/web/robots.py
+++ b/web/robots.py
@@ -6,7 +6,7 @@ import requests
 from robotexclusionrulesparser import RobotExclusionRulesParser, _Ruleset
 
 from web.domains import get_domain
-from web.web_clients import HEADERS_DEFAULT
+from web.web_clients import HEADERS_DEFAULT, select_client
 
 web_client = requests.Session()
 
@@ -27,9 +27,13 @@ _Ruleset.is_not_empty = _PatchedRuleset.is_not_empty
 
 def get_robot_parser(url):
     domain = get_domain(url)
+    _, headers = select_client(domain)
     if domain not in domain_robot_parsers:
         robot_parser = RobotExclusionRulesParser()
-        robots_txt = web_client.get(urljoin(url, "/robots.txt"))
+        robots_txt = web_client.get(
+            urljoin(url, "/robots.txt"),
+            headers=headers,
+        )
         robot_parser.parse(robots_txt.content)
         domain_robot_parsers.set(domain, robot_parser)
     return domain_robot_parsers.get(domain)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
For consistency and transparency, we should send the same `User-Agent` header in our HTTP requests for domain `robots.txt` files as we do when requesting recipe webpage content from those domains.

### Briefly summarize the changes
1. Re-use the existing `web.web_clients.select_client` function to retrieve relevant headers (including `User-Agent`) on a per-domain basis during `robots.txt` retrieval.

### How have the changes been tested?
1. Unit test coverage is provided/updated accordingly.

**List any issues that this change relates to**
Resolves #46.